### PR TITLE
Fix TMDS DC bias accumulation

### DIFF
--- a/dvi/tmds_encoder.py
+++ b/dvi/tmds_encoder.py
@@ -102,9 +102,9 @@ class TMDSEncoder(Elaboratable):
             with m.Elif(((dc_bias[3] == 0) & (data_word_disparity[3] == 0)) |
                         ((dc_bias[3] == 1) & (data_word_disparity[3] == 1))):
                 m.d.pixel += self.o_encoded.eq(Cat(data_word_inv[:8], data_word[8], 0b1))
-                m.d.pixel += dc_bias.eq(dc_bias + data_word[8] - data_word_disparity)
+                m.d.pixel += dc_bias.eq(dc_bias + Cat(0b0, data_word[8]) - data_word_disparity)
             with m.Else():
                 m.d.pixel += self.o_encoded.eq(Cat(data_word, 0b0))
-                m.d.pixel += dc_bias.eq(dc_bias - data_word_inv[8] + data_word_disparity)
+                m.d.pixel += dc_bias.eq(dc_bias - Cat(0b0, data_word_inv[8]) + data_word_disparity)
 
         return m


### PR DESCRIPTION
When accumulating the DC bias the current implementation ignores the effect of `o_encoded[9]` to the bias. This can be fixed by doubling the weight of `data_word(_inv)[8]`, see the following cases:

| `out[8]` | `out[9]` | Total DC bias |
| --- | --- | --- |
| 0 | 0 | -2 |
| 0 | 1 | 0 |
| 1 | 0 | 0 |
| 1 | 1 | +2 |

This doubling is also done in the DVI spec reference encoder flowchart. In nMigen it could be expressed as `data_word[8] * 2` which would probably synthesize to the same thing but I think `Cat(0b0, ...)` is a bit more foolproof.